### PR TITLE
OSOE-847: Removing now unnecessary true isChecked parameter from methods

### DIFF
--- a/Lombiq.Privacy.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.Privacy.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -28,7 +28,7 @@ public static class TestCaseUITestContextExtensions
         context.GetCurrentUri().AbsolutePath.ShouldBe(AbsolutePaths.CompetitorRegistration);
 
         // Now we set consent checkbox to checked.
-        await context.SetCheckboxValueAsync(By.Id("PrivacyConsentCheckboxPart_ConsentCheckbox"), isChecked: true);
+        await context.SetCheckboxValueAsync(By.Id("PrivacyConsentCheckboxPart_ConsentCheckbox"));
         await context.ClickReliablyOnSubmitAsync();
 
         // After submit, it navigates to the new content items view.
@@ -111,7 +111,7 @@ public static class TestCaseUITestContextExtensions
         await context.FillInWithRetriesAsync(By.Id("Email"), TestUser.Email);
         await context.FillInWithRetriesAsync(By.Id("Password"), TestUser.Password);
         await context.FillInWithRetriesAsync(By.Id("ConfirmPassword"), TestUser.Password);
-        await context.SetCheckboxValueAsync(By.Id("RegistrationCheckbox"), isChecked: true);
+        await context.SetCheckboxValueAsync(By.Id("RegistrationCheckbox"));
         await context.ClickReliablyOnSubmitAsync();
 
         // Login with the created user.


### PR DESCRIPTION
[OSOE-847](https://lombiq.atlassian.net/browse/OSOE-847)

[OSOE-847]: https://lombiq.atlassian.net/browse/OSOE-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ